### PR TITLE
migrate to parcel 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules/
 coverage
 
 dist/
-.cache/
+.parcel-cache/
 
 junit.xml
 

--- a/package.json
+++ b/package.json
@@ -4,17 +4,19 @@
   "description": "Twilio Video Room Monitor Javascript Library",
   "main": "dist/node/index.js",
   "types": "dist/node/index.d.ts",
+  "regular": "dist/browser/twilio-video-room-monitor.js",
+  "minified": "dist/browser/twilio-video-room-monitor.min.js",
   "scripts": {
     "start": "tsc --watch",
     "test": "cross-env TZ=utc jest",
     "test:ci": "cross-env TZ=utc jest --ci --runInBand --reporters=default --reporters=jest-junit --coverage --silent",
     "lint": "eslint src",
-    "parcel:watch": "cross-env PARCEL_TARGET=browser parcel src/index.tsx --no-hmr --out-dir dist/browser --out-file twilio-video-room-monitor.js",
+    "parcel:watch": "cross-env PARCEL_TARGET=browser parcel src/index.tsx --no-hmr --dist-dir dist/browser --target regular",
     "prebuild": "rimraf dist/",
     "build": "npm run build:node && npm run build:browser && npm run build:browser:min",
     "build:node": "tsc",
-    "build:browser": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --out-dir dist/browser --out-file twilio-video-room-monitor.js --target browser --no-minify",
-    "build:browser:min": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --out-dir dist/browser --out-file twilio-video-room-monitor.min.js --target browser",
+    "build:browser": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --no-scope-hoist --target regular",
+    "build:browser:min": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --no-scope-hoist --target minified",
     "release": "release",
     "ts": "tsc --noEmit"
   },
@@ -36,13 +38,17 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@swc/helpers": "0.2.14",
+    "@visx/curve": "2.1.0",
     "@visx/xychart": "^1.18.1",
     "d3-array": "^2.12.1",
     "eventemitter3": "^4.0.7",
     "lodash": "^4.17.21",
+    "react-spring": "9.3.2",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {
+    "@parcel/transformer-typescript-types": "2.0.1",
     "@testing-library/react-hooks": "^5.1.2",
     "@types/d3-array": "^2.9.0",
     "@types/enzyme": "^3.10.4",
@@ -68,7 +74,7 @@
     "eslint-plugin-react-hooks": "4.2.0",
     "jest": "26.6.3",
     "jest-junit": "12.0.0",
-    "parcel-bundler": "^1.12.4",
+    "parcel": "^2.0.0",
     "prettier": "^2.2.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
@@ -100,5 +106,28 @@
   "files": [
     "dist/**/!(*.test).js",
     "dist/node/index.d.ts"
-  ]
+  ],
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "targets": {
+    "types": false,
+    "regular": {
+      "distDir": "dist/browser",
+      "optimize": false
+    },
+    "minified": {
+      "distDir": "dist/browser",
+      "optimize": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,19 +4,19 @@
   "description": "Twilio Video Room Monitor Javascript Library",
   "main": "dist/node/index.js",
   "types": "dist/node/index.d.ts",
-  "regular": "dist/browser/twilio-video-room-monitor.js",
-  "minified": "dist/browser/twilio-video-room-monitor.min.js",
+  "browserTarget": "dist/browser/twilio-video-room-monitor.js",
+  "minifiedTarget": "dist/browser/twilio-video-room-monitor.min.js",
   "scripts": {
     "start": "tsc --watch",
     "test": "cross-env TZ=utc jest",
     "test:ci": "cross-env TZ=utc jest --ci --runInBand --reporters=default --reporters=jest-junit --coverage --silent",
     "lint": "eslint src",
-    "parcel:watch": "cross-env PARCEL_TARGET=browser parcel src/index.tsx --no-hmr --dist-dir dist/browser --target regular",
+    "parcel:watch": "cross-env PARCEL_TARGET=browser parcel src/index.tsx --no-hmr --dist-dir dist/browser --target browserTarget",
     "prebuild": "rimraf dist/",
     "build": "npm run build:node && npm run build:browser && npm run build:browser:min",
     "build:node": "tsc",
-    "build:browser": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --target regular",
-    "build:browser:min": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --target minified",
+    "build:browser": "cross-env PARCEL_TARGET=browser parcel build --target browserTarget",
+    "build:browser:min": "cross-env PARCEL_TARGET=browser parcel build --target minifiedTarget",
     "release": "release",
     "ts": "tsc --noEmit"
   },
@@ -119,13 +119,19 @@
     ]
   },
   "targets": {
-    "regular": {
+    "browserTarget": {
+      "source": "src/index.tsx",
       "distDir": "dist/browser",
-      "optimize": false
+      "optimize": false,
+      "sourceMap": false,
+      "scopeHoist": false
     },
-    "minified": {
+    "minifiedTarget": {
+      "source": "src/index.tsx",
       "distDir": "dist/browser",
-      "optimize": true
+      "optimize": true,
+      "sourceMap": false,
+      "scopeHoist": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "prebuild": "rimraf dist/",
     "build": "npm run build:node && npm run build:browser && npm run build:browser:min",
     "build:node": "tsc",
-    "build:browser": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --no-scope-hoist --target regular",
-    "build:browser:min": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --no-scope-hoist --target minified",
+    "build:browser": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --target regular",
+    "build:browser:min": "cross-env PARCEL_TARGET=browser parcel build src/index.tsx --no-source-maps --target minified",
     "release": "release",
     "ts": "tsc --noEmit"
   },
@@ -38,7 +38,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@swc/helpers": "^0.2.14",
     "@visx/curve": "^2.1.0",
     "@visx/xychart": "^1.18.1",
     "d3-array": "^2.12.1",
@@ -48,7 +47,7 @@
     "styled-components": "^5.2.1"
   },
   "devDependencies": {
-    "@parcel/transformer-typescript-types": "2.0.1",
+    "@swc/helpers": "^0.2.14",
     "@testing-library/react-hooks": "^5.1.2",
     "@types/d3-array": "^2.9.0",
     "@types/enzyme": "^3.10.4",
@@ -109,9 +108,9 @@
   ],
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "> 1%, not IE 11",
+      "last 2 and_ff version",
+      "not op_mini all, not opera > 0, not samsung > 0"
     ],
     "development": [
       "last 1 chrome version",
@@ -120,7 +119,6 @@
     ]
   },
   "targets": {
-    "types": false,
     "regular": {
       "distDir": "dist/browser",
       "optimize": false

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@swc/helpers": "0.2.14",
-    "@visx/curve": "2.1.0",
+    "@swc/helpers": "^0.2.14",
+    "@visx/curve": "^2.1.0",
     "@visx/xychart": "^1.18.1",
     "d3-array": "^2.12.1",
     "eventemitter3": "^4.0.7",
     "lodash": "^4.17.21",
-    "react-spring": "9.3.2",
+    "react-spring": "^8.0.27",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {

--- a/src/components/AppContainer/CopyButton/CopyButton.tsx
+++ b/src/components/AppContainer/CopyButton/CopyButton.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import cloneDeepWith from 'lodash/cloneDeepWith';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import useRoom from '../../../hooks/useRoom/useRoom';
@@ -53,8 +53,8 @@ export function CopyButton() {
 
   const handleRoomCopy = () => {
     if (room) {
-      const newRoom = _.cloneDeepWith(room, removeProcessors);
-      const newOptions = _.cloneDeepWith(room._options, removeProcessors);
+      const newRoom = cloneDeepWith(room, removeProcessors);
+      const newOptions = cloneDeepWith(room._options, removeProcessors);
       const text = JSON.stringify({ ...newRoom, connectionOptions: newOptions }, null, 2);
       navigator.clipboard.writeText(text).then(() => {
         setHasCopiedRoomInfo(true);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-7867](https://issues.corp.twilio.com/browse/VIDEO-7867)

### Description

This PR fixes bug #38, where the Twilio Video Room Monitor would crash on the Stats tab when following the instructions under [Script tag](https://github.com/twilio/twilio-video-room-monitor.js) in the Twilio Room Monitor's `README.md`.

This issue was being caused by the parcel-bundler package, which is no longer being maintained. We were able to fix this bug by migrating to Parcel 2. I mainly followed these [instructions](https://parceljs.org/getting-started/migration/), in addition to the [Multiple targets](https://parceljs.org/features/targets/#multiple-targets) instructions being that we wanted to build a minified and a non-minified version of the Room Monitor. I confirmed that that the non-minified version, as well as running `npm run parcel:watch` still work as expected.

Some other things to note:

- we added the package `react-spring` which should resolve this [issue](https://github.com/twilio/twilio-video-app-react/issues/612)
- we added the package `visx/curve`
- we added the package `@swc/helpers` (required by Parcel 2)
- we added the package `@parcel/transformer-typescript-types` (required by Parcel 2)


## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [] Included screenshot as PR comment (if needed) (gif size too big 😞 )
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
