### PR TITLE
Video 7869 fix null values

### DIFF
--- a/src/components/ParticipantInfo/AudioTrackPublicationInfo/AudioTrackPublicationInfo.test.tsx
+++ b/src/components/ParticipantInfo/AudioTrackPublicationInfo/AudioTrackPublicationInfo.test.tsx
@@ -46,7 +46,7 @@ describe('the AudioTrackInfo component', () => {
         packetsLost: null,
       }));
       const wrapper = shallow(<AudioTrackInfo track={{} as any} trackSid="testSid" />);
-      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe('null%');
+      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe(null);
     });
 
     it('should display a value for the RemoteAudioTrack when both packetsReceived and packetsLost are defined', () => {
@@ -93,7 +93,7 @@ describe('the AudioTrackInfo component', () => {
       expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe('0%');
     });
 
-    it('should display 0% for the RemoteAudioTrack when packetsLost is null and packetsReceived is defined', () => {
+    it('should display null for the RemoteAudioTrack when packetsLost is null and packetsReceived is defined', () => {
       mockUseTrackData.mockImplementationOnce(() => ({
         codec: 'testCodec',
         frameRate: null,
@@ -101,10 +101,10 @@ describe('the AudioTrackInfo component', () => {
         packetsReceived: 29448,
       }));
       const wrapper = shallow(<AudioTrackInfo track={{} as any} trackSid="testSid" />);
-      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe('0%');
+      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe(null);
     });
 
-    it('should display 0% for the LocalAudioTrack when packetsLost is null and packetsSent is defined', () => {
+    it('should display null for the LocalAudioTrack when packetsLost is null and packetsSent is defined', () => {
       mockUseTrackData.mockImplementationOnce(() => ({
         codec: 'testCodec',
         frameRate: null,
@@ -112,7 +112,7 @@ describe('the AudioTrackInfo component', () => {
         packetsSent: 2134,
       }));
       const wrapper = shallow(<AudioTrackInfo track={{} as any} trackSid="testSid" />);
-      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe('0%');
+      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe(null);
     });
   });
 });

--- a/src/components/ParticipantInfo/AudioTrackPublicationInfo/AudioTrackPublicationInfo.tsx
+++ b/src/components/ParticipantInfo/AudioTrackPublicationInfo/AudioTrackPublicationInfo.tsx
@@ -30,9 +30,10 @@ export const AudioTrackInfo: React.FC<{
     const { packetsReceived, packetsSent, packetsLost } = trackData;
 
     const totalPackets = packetsReceived ?? packetsSent;
-    const numPacketsLost = packetsLost ?? 0;
+    const numPacketsLost = packetsLost;
 
-    lossPercentage = totalPackets ? ((numPacketsLost / totalPackets) * 100).toLocaleString() : null;
+    lossPercentage =
+      totalPackets && numPacketsLost !== null ? `${((numPacketsLost / totalPackets) * 100).toLocaleString()}%` : null;
   }
 
   return (
@@ -44,7 +45,7 @@ export const AudioTrackInfo: React.FC<{
           <Datum label="Codec" value={trackData.codec} />
           <Datum label="Jitter" value={trackData.jitter} />
           <Datum label="Packets Lost" value={trackData.packetsLost} />
-          <Datum label="Packet Loss Percentage" value={lossPercentage! + '%'} />
+          <Datum label="Packet Loss Percentage" value={lossPercentage!} />
         </>
       )}
       <MediaStreamTrackInfo track={mediaStreamTrack} />

--- a/src/components/ParticipantInfo/AudioTrackPublicationInfo/AudioTrackPublicationInfo.tsx
+++ b/src/components/ParticipantInfo/AudioTrackPublicationInfo/AudioTrackPublicationInfo.tsx
@@ -24,16 +24,15 @@ export const AudioTrackInfo: React.FC<{
   const trackData = useTrackData(trackSid) as LocalAudioTrackStats | RemoteAudioTrackStats | null;
   const mediaStreamTrack = useMediaStreamTrack(track);
 
-  let lossPercentage: string | null;
+  let lossPercentage: string | null = '';
 
   if (trackData) {
     const { packetsReceived, packetsSent, packetsLost } = trackData;
 
     const totalPackets = packetsReceived ?? packetsSent;
-    const numPacketsLost = packetsLost;
 
     lossPercentage =
-      totalPackets && numPacketsLost !== null ? `${((numPacketsLost / totalPackets) * 100).toLocaleString()}%` : null;
+      totalPackets && packetsLost !== null ? `${((packetsLost / totalPackets) * 100).toLocaleString()}%` : null;
   }
 
   return (
@@ -45,7 +44,7 @@ export const AudioTrackInfo: React.FC<{
           <Datum label="Codec" value={trackData.codec} />
           <Datum label="Jitter" value={trackData.jitter} />
           <Datum label="Packets Lost" value={trackData.packetsLost} />
-          <Datum label="Packet Loss Percentage" value={lossPercentage!} />
+          <Datum label="Packet Loss Percentage" value={lossPercentage} />
         </>
       )}
       <MediaStreamTrackInfo track={mediaStreamTrack} />

--- a/src/components/ParticipantInfo/AudioTrackPublicationInfo/__snapshots__/AudioTrackPublicationInfo.test.tsx.snap
+++ b/src/components/ParticipantInfo/AudioTrackPublicationInfo/__snapshots__/AudioTrackPublicationInfo.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`the AudioTrackInfo component should render correctly if an audio track 
   />
   <Memo(Datum)
     label="Packet Loss Percentage"
-    value="null%"
+    value={null}
   />
   <Memo(MediaStreamTrackInfo) />
 </Fragment>

--- a/src/components/ParticipantInfo/VideoTrackPublicationInfo/VideoTrackPublicationInfo.test.tsx
+++ b/src/components/ParticipantInfo/VideoTrackPublicationInfo/VideoTrackPublicationInfo.test.tsx
@@ -63,7 +63,7 @@ describe('the VideoTrackInfo component', () => {
         packetsLost: null,
       }));
       const wrapper = shallow(<VideoTrackInfo track={{} as any} trackSid="testSid" />);
-      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe('null%');
+      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe(null);
     });
 
     it('should display a value for the RemoteVideoTrack when both packetsReceived and packetsLost are defined', () => {
@@ -110,7 +110,7 @@ describe('the VideoTrackInfo component', () => {
       expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe('0%');
     });
 
-    it('should display 0% for the RemoteVideoTrack when packetsLost is null and packetsReceived is defined', () => {
+    it('should display null for the RemoteVideoTrack when packetsLost is null and packetsReceived is defined', () => {
       mockUseTrackData.mockImplementationOnce(() => ({
         codec: 'testCodec',
         frameRate: null,
@@ -118,10 +118,10 @@ describe('the VideoTrackInfo component', () => {
         packetsReceived: 29448,
       }));
       const wrapper = shallow(<VideoTrackInfo track={{} as any} trackSid="testSid" />);
-      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe('0%');
+      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe(null);
     });
 
-    it('should display 0% for the LocalVideoTrack when packetsLost is null and packetsSent is defined', () => {
+    it('should display null for the LocalVideoTrack when packetsLost is null and packetsSent is defined', () => {
       mockUseTrackData.mockImplementationOnce(() => ({
         codec: 'testCodec',
         frameRate: null,
@@ -129,7 +129,7 @@ describe('the VideoTrackInfo component', () => {
         packetsSent: 2134,
       }));
       const wrapper = shallow(<VideoTrackInfo track={{} as any} trackSid="testSid" />);
-      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe('0%');
+      expect(wrapper.find({ label: 'Packet Loss Percentage' }).prop('value')).toBe(null);
     });
   });
 });

--- a/src/components/ParticipantInfo/VideoTrackPublicationInfo/VideoTrackPublicationInfo.tsx
+++ b/src/components/ParticipantInfo/VideoTrackPublicationInfo/VideoTrackPublicationInfo.tsx
@@ -42,9 +42,10 @@ export const VideoTrackInfo: React.FC<{
     const { packetsReceived, packetsSent, packetsLost } = trackData;
 
     const totalPackets = packetsReceived ?? packetsSent;
-    const numPacketsLost = packetsLost ?? 0;
+    const numPacketsLost = packetsLost;
 
-    lossPercentage = totalPackets ? ((numPacketsLost / totalPackets) * 100).toLocaleString() : null;
+    lossPercentage =
+      totalPackets && numPacketsLost !== null ? `${((numPacketsLost / totalPackets) * 100).toLocaleString()}%` : null;
   }
 
   return (
@@ -59,7 +60,7 @@ export const VideoTrackInfo: React.FC<{
           <Datum label="Codec" value={trackData.codec} />
           <Datum label="Framerate" value={trackData?.frameRate} />
           <Datum label="Packets Lost" value={trackData?.packetsLost} />
-          <Datum label="Packet Loss Percentage" value={lossPercentage! + '%'} />
+          <Datum label="Packet Loss Percentage" value={lossPercentage!} />
         </>
       )}
       <MediaStreamTrackInfo track={mediaStreamTrack} />

--- a/src/components/ParticipantInfo/VideoTrackPublicationInfo/VideoTrackPublicationInfo.tsx
+++ b/src/components/ParticipantInfo/VideoTrackPublicationInfo/VideoTrackPublicationInfo.tsx
@@ -36,16 +36,15 @@ export const VideoTrackInfo: React.FC<{
   const trackData = useTrackData(trackSid) as LocalVideoTrackStats | RemoteVideoTrackStats | null;
   const mediaStreamTrack = useMediaStreamTrack(track);
 
-  let lossPercentage: string | null;
+  let lossPercentage: string | null = '';
 
   if (trackData) {
     const { packetsReceived, packetsSent, packetsLost } = trackData;
 
     const totalPackets = packetsReceived ?? packetsSent;
-    const numPacketsLost = packetsLost;
 
     lossPercentage =
-      totalPackets && numPacketsLost !== null ? `${((numPacketsLost / totalPackets) * 100).toLocaleString()}%` : null;
+      totalPackets && packetsLost !== null ? `${((packetsLost / totalPackets) * 100).toLocaleString()}%` : null;
   }
 
   return (
@@ -60,7 +59,7 @@ export const VideoTrackInfo: React.FC<{
           <Datum label="Codec" value={trackData.codec} />
           <Datum label="Framerate" value={trackData?.frameRate} />
           <Datum label="Packets Lost" value={trackData?.packetsLost} />
-          <Datum label="Packet Loss Percentage" value={lossPercentage!} />
+          <Datum label="Packet Loss Percentage" value={lossPercentage} />
         </>
       )}
       <MediaStreamTrackInfo track={mediaStreamTrack} />

--- a/src/components/ParticipantInfo/VideoTrackPublicationInfo/__snapshots__/VideoTrackPublicationInfo.test.tsx.snap
+++ b/src/components/ParticipantInfo/VideoTrackPublicationInfo/__snapshots__/VideoTrackPublicationInfo.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`the VideoTrackInfo component should render correctly if a video track i
   />
   <Memo(Datum)
     label="Packet Loss Percentage"
-    value="null%"
+    value={null}
   />
   <Memo(MediaStreamTrackInfo) />
 </Fragment>

--- a/src/hooks/useStats/useStatsUtils.test.ts
+++ b/src/hooks/useStats/useStatsUtils.test.ts
@@ -143,7 +143,7 @@ describe('the removeInactiveLayers function', () => {
     },
   ];
 
-  it('should return an array with all tracks for a specific trackSid that have an increased bytesSent value', () => {
+  it('should return an array with all tracks for a specific trackSid that have an updated bytesSent value', () => {
     expect(statsHooks.removeInactiveLayers(previousStats as any, stats as any, 'mockTrackSid')).toEqual([
       { trackSid: 'mockTrackSid', bytesSent: 40000, ssrc: 1 },
       { trackSid: 'mockTrackSid', bytesSent: 30000, ssrc: 2 },

--- a/src/hooks/useStats/useStatsUtils.test.ts
+++ b/src/hooks/useStats/useStatsUtils.test.ts
@@ -117,6 +117,48 @@ describe('the getTrackData function', () => {
   });
 });
 
+describe('the removeInactiveLayers function', () => {
+  const stats = [
+    {
+      localAudioTrackStats: [],
+      localVideoTrackStats: [
+        { trackSid: 'mockTrackSid', bytesSent: 40000, ssrc: 1 },
+        { trackSid: 'mockTrackSid', bytesSent: 30000, ssrc: 2 },
+        { trackSid: 'mockTrackSid', bytesSent: 20000, ssrc: 3 },
+      ],
+      remoteAudioTrackStats: [],
+      remoteVideoTrackStats: [],
+    },
+  ];
+  const previousStats = [
+    {
+      localAudioTrackStats: [],
+      localVideoTrackStats: [
+        { trackSid: 'mockTrackSid', bytesSent: 35000, ssrc: 1 },
+        { trackSid: 'mockTrackSid', bytesSent: 25000, ssrc: 2 },
+        { trackSid: 'mockTrackSid', bytesSent: 20000, ssrc: 3 },
+      ],
+      remoteAudioTrackStats: [],
+      remoteVideoTrackStats: [],
+    },
+  ];
+
+  it('should return an array with all tracks for a specific trackSid that have an increased bytesSent value', () => {
+    expect(statsHooks.removeInactiveLayers(previousStats as any, stats as any, 'mockTrackSid')).toEqual([
+      { trackSid: 'mockTrackSid', bytesSent: 40000, ssrc: 1 },
+      { trackSid: 'mockTrackSid', bytesSent: 30000, ssrc: 2 },
+    ]);
+  });
+
+  it('should return null when "stats" is undefined', () => {
+    expect(statsHooks.removeInactiveLayers(previousStats as any, undefined, 'mockTrackSid')).toEqual(null);
+  });
+
+  it('should return null when "stats" and "previousStats" are undefined', () => {
+    expect(statsHooks.removeInactiveLayers(undefined, undefined, 'mockTrackSid')).toEqual(null);
+  });
+});
+
 describe('the useTrackBandwidth function', () => {
   it('should return null if there are no previous stats', () => {
     mockUseStats.mockImplementationOnce(() => ({
@@ -204,8 +246,8 @@ describe('the useTrackData function', () => {
       stats: [
         {
           localAudioTrackStats: [
-            { trackSid: 'mockTrackSid', name: 'mockTrack1' },
-            { trackSid: 'mockTrackSid', name: 'mockTrack2' },
+            { trackSid: 'mockTrackSid', name: 'mockTrack1', ssrc: 'mockSsrc1', bytesSent: 5 },
+            { trackSid: 'mockTrackSid', name: 'mockTrack2', ssrc: 'mockSsrc2', bytesSent: 4 },
           ],
           localVideoTrackStats: [],
           remoteAudioTrackStats: [],
@@ -214,14 +256,22 @@ describe('the useTrackData function', () => {
       ],
       previousStats: [
         {
-          localAudioTrackStats: [],
+          localAudioTrackStats: [
+            { trackSid: 'mockTrackSid', name: 'mockTrack1', ssrc: 'mockSsrc1', bytesSent: 2 },
+            { trackSid: 'mockTrackSid', name: 'mockTrack2', ssrc: 'mockSsrc2', bytesSent: 2 },
+          ],
           localVideoTrackStats: [],
           remoteAudioTrackStats: [],
           remoteVideoTrackStats: [],
         },
       ],
     }));
-    expect(statsHooks.useTrackData('mockTrackSid')).toEqual({ trackSid: 'mockTrackSid', name: 'mockTrack1' });
+    expect(statsHooks.useTrackData('mockTrackSid')).toEqual({
+      trackSid: 'mockTrackSid',
+      name: 'mockTrack1',
+      ssrc: 'mockSsrc1',
+      bytesSent: 5,
+    });
   });
 });
 

--- a/src/hooks/useStats/useStatsUtils.test.ts
+++ b/src/hooks/useStats/useStatsUtils.test.ts
@@ -117,7 +117,7 @@ describe('the getTrackData function', () => {
   });
 });
 
-describe('the removeInactiveLayers function', () => {
+describe('the getActiveTrackData function', () => {
   const stats = [
     {
       localAudioTrackStats: [],
@@ -144,18 +144,10 @@ describe('the removeInactiveLayers function', () => {
   ];
 
   it('should return an array with all tracks for a specific trackSid that have an updated bytesSent value', () => {
-    expect(statsHooks.removeInactiveLayers(previousStats as any, stats as any, 'mockTrackSid')).toEqual([
+    expect(statsHooks.getActiveTrackData(previousStats as any, stats as any, 'mockTrackSid')).toEqual([
       { trackSid: 'mockTrackSid', bytesSent: 40000, ssrc: 1 },
       { trackSid: 'mockTrackSid', bytesSent: 30000, ssrc: 2 },
     ]);
-  });
-
-  it('should return null when "stats" is undefined', () => {
-    expect(statsHooks.removeInactiveLayers(previousStats as any, undefined, 'mockTrackSid')).toEqual(null);
-  });
-
-  it('should return null when "stats" and "previousStats" are undefined', () => {
-    expect(statsHooks.removeInactiveLayers(undefined, undefined, 'mockTrackSid')).toEqual(null);
   });
 });
 

--- a/src/hooks/useStats/useStatsUtils.ts
+++ b/src/hooks/useStats/useStatsUtils.ts
@@ -43,12 +43,11 @@ export function getTrackData(trackSid: string, statsReports: StatsReport[]) {
 
 // Returns an array that only contains tracks that correspond to a simulcast layer
 // that is currently in use. All "configured" but inactive layers will be filtered out.
-export function removeInactiveLayers(
-  previousStats: StatsReport[] | undefined,
-  stats: StatsReport[] | undefined,
+export function getActiveTrackData(
+  previousStats: StatsReport[],
+  stats: StatsReport[],
   trackSid: string
 ) {
-  if (!stats || !previousStats) return null;
 
   const previousTracks = getTrackData(trackSid, previousStats);
   const currentTracks = getTrackData(trackSid, stats);
@@ -133,7 +132,7 @@ export function useTrackData(trackSid: string) {
   const { stats, previousStats } = useStats();
   if (!stats || !previousStats) return null;
 
-  const trackData = removeInactiveLayers(previousStats, stats, trackSid);
+  const trackData = getActiveTrackData(previousStats, stats, trackSid);
 
-  return trackData![0];
+  return trackData[0];
 }

--- a/src/hooks/useStats/useStatsUtils.ts
+++ b/src/hooks/useStats/useStatsUtils.ts
@@ -55,7 +55,7 @@ export function removeInactiveLayers(
 
   const activeLayers = currentTracks.filter((currentTrack) => {
     const previousTrack = previousTracks.find((t) => t.ssrc === currentTrack.ssrc);
-    return currentTrack?.bytesSent! > previousTrack?.bytesSent!;
+    return currentTrack.bytesSent !== previousTrack?.bytesSent;
   });
 
   return activeLayers;


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-7869](https://issues.corp.twilio.com/browse/VIDEO-7869)

### Description

This PR makes the following updates to the Video Room Monitor:
- Sets `Packet Loss %` to `null` when `packetLoss` is `null` instead of 0%:
![Screen Shot 2021-12-13 at 5 17 34 PM](https://user-images.githubusercontent.com/77076398/145915723-060e4d83-2036-41d0-9035-e3d028ced885.png)
- Sets `Packet Loss %` to `0%` when `packetLoss` is `0`:
![Screen Shot 2021-12-13 at 5 17 26 PM](https://user-images.githubusercontent.com/77076398/145915770-9fa950fd-3f15-410d-9ed8-8481d3f5158c.png)
- Removes simulcast layers that are inactive. The `Room.getStats()` function returns all tracks that correspond to a configured simulcast layer, even if they are not in use. To determine if a layer is in use, the `bytesSent` value will be increasing continuously. This ensures that the Room Monitor will never display information about tracks that not even in use.



## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
